### PR TITLE
Run load hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ pkg
 
 ## PROJECT::SPECIFIC
 Gemfile.lock
+*.iml
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ tmtags
 
 ## IntelliJ/Rubymine
 .idea
+*.iml
 
 ## PROJECT::GENERAL
 coverage
@@ -23,5 +24,3 @@ pkg
 
 ## PROJECT::SPECIFIC
 Gemfile.lock
-*.iml
-.idea/

--- a/lib/postgresql_cursor/cursor.rb
+++ b/lib/postgresql_cursor/cursor.rb
@@ -303,4 +303,6 @@ module PostgreSQLCursor
       frac
     end
   end
+
+  ActiveSupport.run_load_hooks(PostgreSQLCursor.name.underscore.to_sym, self)
 end

--- a/test/test_postgresql_cursor.rb
+++ b/test/test_postgresql_cursor.rb
@@ -191,4 +191,10 @@ class TestPostgresqlCursor < Minitest::Test
       assert_match(/bad_table/, e.message)
     end
   end
+
+  def test_on_load_hook
+    i = 0
+    ActiveSupport.on_load(:postgre_sql_cursor) { i += 1 }
+    assert_equal(1, i, "The loading hook didn't run")
+  end
 end


### PR DESCRIPTION
## Issue
We have a project that uses custom pg types that use special coercion. We used a patch to prepend code by another gem but after this commit 3ef0bcc, the PostgreSQLCursor class wasn't being loaded when the other gem was (i.e we had require 'postgresql_cursor/type_coercion_fix' if defined?(PostgreSQLCursor))

## Solution
After this gem loads, run the run_load_hooks callback so other gems can add extra configuration to it.